### PR TITLE
Use api-client-go's APIError

### DIFF
--- a/error.go
+++ b/error.go
@@ -14,6 +14,13 @@
 
 package kms
 
+import (
+	"errors"
+
+	ogen "github.com/ogen-go/ogen/validate"
+	client "github.com/sacloud/api-client-go"
+)
+
 type Error struct {
 	msg string
 	err error
@@ -36,8 +43,20 @@ func (e *Error) Unwrap() error {
 }
 
 func NewError(msg string, err error) *Error {
-	if err == nil {
-		return &Error{msg: msg}
-	}
 	return &Error{msg: msg, err: err}
+}
+
+func NewAPIError(method string, code int, err error) *Error {
+	return &Error{msg: method, err: client.NewAPIError(code, "", err)}
+}
+
+// kmsのOpenAPI定義でエラーケースが定義されていないので、現状はogenのエラーから状態を取り出す
+// NewAPIErrorは他のクライアントとインターフェイスを揃えるために維持し、別で生成関数を用意
+func createAPIError(method string, err error) error {
+	var unexpected *ogen.UnexpectedStatusCodeError
+	if errors.As(err, &unexpected) {
+		return NewAPIError(method, unexpected.StatusCode, err)
+	}
+
+	return NewAPIError(method, 0, err)
 }

--- a/error_test.go
+++ b/error_test.go
@@ -3,6 +3,8 @@ package kms
 import (
 	"errors"
 	"testing"
+
+	client "github.com/sacloud/api-client-go"
 )
 
 func TestError_Error(t *testing.T) {
@@ -51,5 +53,19 @@ func TestNewError(t *testing.T) {
 	err2 := NewError("msg only", nil)
 	if err2.msg != "msg only" || err2.err != nil {
 		t.Errorf("NewError() with nil err did not set fields correctly")
+	}
+}
+
+func TestNewAPIError(t *testing.T) {
+	baseErr := errors.New("base error")
+
+	err := NewAPIError("msg", 404, baseErr)
+	if !client.IsNotFoundError(err) {
+		t.Errorf("IsNotFoundError is true for NewAPIError with 404")
+	}
+
+	err2 := NewAPIError("msg", 503, nil)
+	if client.IsNotFoundError(err2) {
+		t.Errorf("IsNotFoundError is false for NewAPIError with 503")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.1.0
 	github.com/ogen-go/ogen v1.14.0
-	github.com/sacloud/api-client-go v0.3.0
+	github.com/sacloud/api-client-go v0.3.2
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/go-faster/yaml v0.4.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
+github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
+github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -38,6 +40,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sacloud/api-client-go v0.3.0 h1:NLA2BpZ5welAXBPxgmXSCjgn/k0ShDB0x5kmUHl7TJ4=
 github.com/sacloud/api-client-go v0.3.0/go.mod h1:v8ke3pxVQ9TCWEbMkfbLX8NMeGiPpE+uDwlgcUWfMgM=
+github.com/sacloud/api-client-go v0.3.2 h1:INbdSpQbyGN9Ai4hQ+Gbv3UQcgtRPG2tJrOmqT7HGl0=
+github.com/sacloud/api-client-go v0.3.2/go.mod h1:0p3ukcWYXRCc2AUWTl1aA+3sXLvurvvDqhRaLZRLBwo=
 github.com/sacloud/go-http v0.1.9 h1:Xa5PY8/pb7XWhwG9nAeXSrYXPbtfBWqawgzxD5co3VE=
 github.com/sacloud/go-http v0.1.9/go.mod h1:DpDG+MSyxYaBwPJ7l3aKLMzwYdTVtC5Bo63HActcgoE=
 github.com/sacloud/packages-go v0.0.11 h1:hrRWLmfPM9w7GBs6xb5/ue6pEMl8t1UuDKyR/KfteHo=

--- a/keys.go
+++ b/keys.go
@@ -41,7 +41,7 @@ func NewKeyOp(client *v1.Client) KeyAPI {
 func (op *keyOp) List(ctx context.Context) (v1.Keys, error) {
 	res, err := op.client.KmsKeysList(ctx)
 	if err != nil {
-		return nil, NewError("List", err)
+		return nil, createAPIError("List", err)
 	}
 	return res.Keys, nil
 }
@@ -49,7 +49,7 @@ func (op *keyOp) List(ctx context.Context) (v1.Keys, error) {
 func (op *keyOp) Read(ctx context.Context, id string) (*v1.Key, error) {
 	res, err := op.client.KmsKeysRetrieve(ctx, v1.KmsKeysRetrieveParams{ResourceID: id})
 	if err != nil {
-		return nil, NewError("Read", err)
+		return nil, createAPIError("Read", err)
 	}
 	return &res.Key, nil
 }
@@ -59,7 +59,7 @@ func (op *keyOp) Create(ctx context.Context, request v1.CreateKey) (*v1.CreateKe
 		Key: request,
 	})
 	if err != nil {
-		return nil, NewError("Create", err)
+		return nil, createAPIError("Create", err)
 	}
 	return &res.Key, nil
 }
@@ -69,7 +69,7 @@ func (op *keyOp) Update(ctx context.Context, id string, request v1.Key) (*v1.Key
 		Key: request,
 	}, v1.KmsKeysUpdateParams{ResourceID: id})
 	if err != nil {
-		return nil, NewError("Update", err)
+		return nil, createAPIError("Update", err)
 	}
 	return &res.Key, nil
 }
@@ -77,7 +77,7 @@ func (op *keyOp) Update(ctx context.Context, id string, request v1.Key) (*v1.Key
 func (op *keyOp) Delete(ctx context.Context, id string) error {
 	err := op.client.KmsKeysDestroy(ctx, v1.KmsKeysDestroyParams{ResourceID: id})
 	if err != nil {
-		return NewError("Delete", err)
+		return createAPIError("Delete", err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

api-client-goに実装されたAPIErrorを使ってエラーを返すようにする。
丸められたエラーではなくステータスコード等も取得できるようになるので、それによって処理を分けられるようになる。
現状KMSのOpenAPI定義にはエラーのケースがなくて型で判別できないので、ogenのエラーからステータスコードを取り出す処理を挟んでいる。

### ドキュメントの変更は必要ですか？

必要無し